### PR TITLE
When indexing ContentAggregators (which index fulltext of children in…

### DIFF
--- a/app/models/content_aggregator.rb
+++ b/app/models/content_aggregator.rb
@@ -3,8 +3,9 @@ class ContentAggregator < GenericAggregator
   rdf_types(RDF::PCDM.Object)
   def to_solr(solr_doc = Hash.new, opts={})
     solr_doc = super
-    self.members.each do |member_doc|
-      member = ActiveFedora::Base.find(member_doc['id'])
+
+    Cul::Hydra::RisearchMembers.get_direct_members_with_datastream_pids(self.pid, 'fulltext').each do |pid|
+      member = ActiveFedora::Base.find(pid)
       if member.is_a? GenericResource
         member_doc = member.to_solr
         unless member_doc["fulltext_tesim"].blank?
@@ -12,6 +13,7 @@ class ContentAggregator < GenericAggregator
         end
       end
     end
+
     solr_doc
   end
 end

--- a/lib/cul_hydra/risearch_members.rb
+++ b/lib/cul_hydra/risearch_members.rb
@@ -70,7 +70,6 @@ module ClassMethods
       count( select $ds from <#ri> where  $pid <fedora-view:disseminates> $ds and $ds <fedora-view:disseminationType> <info:fedora/*/#{dsid}>)
       from <#ri>
       where $pid <http://purl.oclc.org/NET/CUL/memberOf> <info:fedora/#{pid}>
-      and $pid <fedora-view:disseminates> $ds
       having $k0 <http://mulgara.org/mulgara#occursMoreThan> '0.0'^^<http://www.w3.org/2001/XMLSchema#double>;"
 
       puts 'Performing query:' if verbose_output

--- a/lib/cul_hydra/risearch_members.rb
+++ b/lib/cul_hydra/risearch_members.rb
@@ -6,7 +6,7 @@ module ClassMethods
     recursive_member_query =
       'select $child $parent from <#ri>
       where
-      walk($child <http://purl.oclc.org/NET/CUL/memberOf> <fedora:' + pid + '> and $child <http://purl.oclc.org/NET/CUL/memberOf> $parent)'      
+      walk($child <http://purl.oclc.org/NET/CUL/memberOf> <fedora:' + pid + '> and $child <http://purl.oclc.org/NET/CUL/memberOf> $parent)'
 
     unless cmodel_type == 'all'
       recursive_member_query += ' and $child <fedora-model:hasModel> $cmodel'
@@ -59,6 +59,39 @@ module ClassMethods
     return count.blank? ? 0 : count[0]['count'].to_i
   end
 
+  def get_direct_members_with_datastream_results(pid, dsid, flush_resource_index_before_query=false, verbose_output=false, format='json')
+    # Note: The query we're using below is a faster version of this query:
+    #   "select $pid from <#ri>
+    #   where $pid <http://purl.oclc.org/NET/CUL/memberOf> <fedora:#{pid}>
+    #   and $pid <fedora-view:disseminates> $ds
+    #   and $ds <fedora-view:disseminationType> <info:fedora/*/#{dsid}>"
+
+    direct_members_with_ds_query = "select $pid
+      count( select $ds from <#ri> where  $pid <fedora-view:disseminates> $ds and $ds <fedora-view:disseminationType> <info:fedora/*/#{dsid}>)
+      from <#ri>
+      where $pid <http://purl.oclc.org/NET/CUL/memberOf> <info:fedora/#{pid}>
+      and $pid <fedora-view:disseminates> $ds
+      having $k0 <http://mulgara.org/mulgara#occursMoreThan> '0.0'^^<http://www.w3.org/2001/XMLSchema#double>;"
+
+      puts 'Performing query:' if verbose_output
+      puts direct_members_with_ds_query if verbose_output
+
+      search_response = JSON.parse(Cul::Hydra::Fedora.repository.find_by_itql(direct_members_with_ds_query, {
+        :type => 'tuples',
+        :format => format,
+        :limit => '',
+        :stream => 'on',
+        :flush => flush_resource_index_before_query.to_s
+      }))
+
+      return search_response['results']
+  end
+
+  def get_direct_members_with_datastream_pids(pid, dsid, flush_resource_index_before_query=false, verbose_output=false)
+    unique_pids = get_direct_members_with_datastream_results(pid, dsid, flush_resource_index_before_query, verbose_output, 'json')
+    unique_pids.map{|result| result['pid'].gsub('info:fedora/', '') }.uniq
+  end
+
   #Project constituents
 
   def get_project_constituent_results(pid, verbose_output=false, format='json')
@@ -89,9 +122,9 @@ module ClassMethods
     count = get_project_constituent_results(pid,verbose_output,'count/json')
     return count.blank? ? 0 : count[0]['count'].to_i
   end
-  
+
   #Publish target members
-  
+
   def get_publish_target_member_results(pid, verbose_output=false, format='json')
 
     project_constituent_query =
@@ -120,13 +153,13 @@ module ClassMethods
     count = get_publish_target_member_results(pid,verbose_output,'count/json')
     return count.blank? ? 0 : count[0]['count'].to_i
   end
-  
+
   # Returns the pid of the first object found with the given identifier
   def get_pid_for_identifier(identifier, flush_resource_index_before_query=false)
     find_by_identifier_query = "select $pid from <#ri>
     where $pid <http://purl.org/dc/elements/1.1/identifier> $identifier
     and $identifier <mulgara:is> '#{identifier}'"
-    
+
     search_response = JSON(Cul::Hydra::Fedora.repository.find_by_itql(find_by_identifier_query, {
       :type => 'tuples',
       :format => 'json',
@@ -134,39 +167,39 @@ module ClassMethods
       :stream => 'on',
       :flush => flush_resource_index_before_query.to_s
     }))
-    
+
     if search_response['results'].present?
       return search_response['results'].first['pid'].gsub('info:fedora/', '')
     else
       return nil
     end
   end
-  
+
   # Returns the pids of ALL objects found with the given identifier
   def get_all_pids_for_identifier(identifier)
-    
+
     find_by_identifier_query = "select $pid from <#ri>
     where $pid <http://purl.org/dc/elements/1.1/identifier> $identifier
     and $identifier <mulgara:is> '#{identifier}'"
-    
+
     search_response = JSON(Cul::Hydra::Fedora.repository.find_by_itql(find_by_identifier_query, {
       :type => 'tuples',
       :format => 'json',
       :limit => '',
       :stream => 'on'
     }))
-    
+
     pids_to_return = []
-    
+
     if search_response['results'].present?
       search_response['results'].each do |result|
         pids_to_return << result['pid'].gsub('info:fedora/', '')
       end
     end
-    
+
     return pids_to_return
   end
-  
+
 end
 extend ClassMethods
 end

--- a/lib/cul_hydra/solrizer/mods_fieldable.rb
+++ b/lib/cul_hydra/solrizer/mods_fieldable.rb
@@ -64,13 +64,13 @@ module Cul::Hydra::Solrizer
         ModsFieldable.normalize(main_title(p_node), true)
       end
     end
-    
+
     def languages_iso639_2_text
       mods.xpath("./mods:language/mods:languageTerm[@type='text' and @authority='iso639-2']", MODS_NS).collect do |n|
         ModsFieldable.normalize(n.text, true)
       end
     end
-    
+
     def languages_iso639_2_code
       mods.xpath("./mods:language/mods:languageTerm[@type='code' and @authority='iso639-2']", MODS_NS).collect do |n|
         ModsFieldable.normalize(n.text, true)
@@ -210,7 +210,7 @@ module Cul::Hydra::Solrizer
       end
       values
     end
-    
+
     def sublocation(node=mods)
       values = node.xpath("./mods:location/mods:sublocation", MODS_NS).collect do |n|
         ModsFieldable.normalize(n.text, true)
@@ -483,7 +483,7 @@ module Cul::Hydra::Solrizer
 
       # Geo data
       solr_doc["geo"] = coordinates
-      
+
       ## Handle alternate form of language authority for language_language_term_text_ssim
       ## We already capture elements when authority="iso639-2b", but we want to additionally
       ## capture language elements when authority="iso639-2".

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,16 @@ end
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
+
+  # Remove the line below when we update to rspec 3
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 end
 def absolute_fixture_path(file)
   File.realpath(File.join(File.dirname(__FILE__), '..','fixtures','spec', file))

--- a/spec/unit/models/concept_spec.rb
+++ b/spec/unit/models/concept_spec.rb
@@ -101,7 +101,7 @@ describe Concept, type: :unit do
       concept = Concept.new
       concept
     }
-    it "clears a relationship if nil or empty value is passed as an argument", focus: true do
+    it "clears a relationship if nil or empty value is passed as an argument" do
       concept.abstract = 'Some abstract'
       expect(concept.relationships(:abstract).length).to eq(1)
       concept.set_singular_rel(:abstract, nil, true)
@@ -113,7 +113,7 @@ describe Concept, type: :unit do
       concept = Concept.new
       concept
     }
-    it "when passed a nil or empty string value, removes the :description relationship and deletes the associated description datastream", focus: true do
+    it "when passed a nil or empty string value, removes the :description relationship and deletes the associated description datastream" do
       [nil, ''].each do |val|
         concept.description = 'Some description'
         expect(concept.description).to eq('Some description')

--- a/spec/unit/models/content_aggregator_spec.rb
+++ b/spec/unit/models/content_aggregator_spec.rb
@@ -41,13 +41,13 @@ describe ContentAggregator, type: :unit do
     context 'an aggregated resource has a fulltext index' do
       let(:aggregator) {
         agg = ContentAggregator.new
-        allow(agg).to receive(:members).and_return([part_doc])
+        allow(Cul::Hydra::Fedora.repository).to receive(:find_by_itql).and_return(risearch_response)
         allow(agg).to receive(:get_representative_generic_resource).and_return(part)
         allow(agg).to receive(:set_size_labels)
         agg
       }
       let(:fulltext) { ['fulltext'] }
-      let(:part_doc) { {'id' => 'foo'} }
+      let(:risearch_response) { '{"results":[{"pid":"info:fedora/ldpd:123", "k0":"1"}]}' }
       let(:part) {
         part = GenericResource.new
         allow(part).to receive(:to_solr).and_return("fulltext_tesim" => fulltext)
@@ -55,7 +55,7 @@ describe ContentAggregator, type: :unit do
       }
       subject { aggregator.to_solr }
       before do
-        allow(ActiveFedora::Base).to receive(:find).with('foo').and_return(part)
+        allow(ActiveFedora::Base).to receive(:find).with('ldpd:123').and_return(part)
       end
       it do
         is_expected.to include('fulltext_tesim')


### PR DESCRIPTION
…to parent fulltext field), use risearch query as more efficient way of handling many children; Also enable focus param on tests